### PR TITLE
fix: check for data in buffer before write

### DIFF
--- a/file-store/src/database.ts
+++ b/file-store/src/database.ts
@@ -197,8 +197,11 @@ export class Database<T extends Tables, D extends Dest> implements FinalDatabase
         }
 
         if (
-            chunkSize >= this.chunkSize * 1024 * 1024 ||
-            (info.isOnTop && newState.height - prevState.height >= this.updateInterval)
+            chunkSize > 0 && 
+            (
+                chunkSize >= this.chunkSize * 1024 * 1024 ||
+                (info.isOnTop && newState.height - prevState.height >= this.updateInterval)
+            )
         ) {
             await this.flush(prevState, newState, this.chunk)
             await this.hooks.onStateUpdate(this.dest, newState)


### PR DESCRIPTION
The [documentation](https://docs.subsquid.io/store/file-store/overview/#filesystem-syncs-and-dataset-partitioning) around `syncIntervalBlocks` suggests there should be at least one row of data in the buffer prior to a write.

This isn't the behaviour in practice.  This was an issue for me writing sparse data to parquet files - when a `syncIntervalBlocks` boundary was crossed an 'empty' parquet file was written.  These files then cause errors on downstream imports due to having no row groups.

This fix adds an additional check for data in the buffer prior to writing, which seems to be the intent of the documentation.